### PR TITLE
feat(ci): add tests-pass job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Depends on all action sthat are required for a "successful" CI run.
+  tests-pass:
+    name: all systems go
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - clippy
+      - rustfmt
+    steps:
+      - run: exit 0
+
   gather_crates:
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Description

Setting jobs as `required` via github settings requires us to do it per `matrix` entry. This PR defines instead a `tests-pass` job that can depend instead on the name of the `test` job and make our lives easier.  