### PR TITLE
feat(ci): run workflows on merge_group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continuous integration
 
 on:
+  merge_group:
   pull_request:
   push:
     branches:

--- a/.github/workflows/conventional_pr_title.yml
+++ b/.github/workflows/conventional_pr_title.yml
@@ -1,5 +1,6 @@
 name: Check PR title
 on:
+  merge_group:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
## Description

We have set `tests-pass` and `conventional-pr-title` as required for the PRs to be merged. With the new merge queue activated, a new `merge_group` step is introduced which requires again for these workflows to run, as github doesn't allow switching that off for now, we enable those workflows again with this PR for `merge_group`.