### PR TITLE
fix(ci): do not run conventional title check on merge_group

### DIFF
--- a/.github/workflows/conventional_pr_title.yml
+++ b/.github/workflows/conventional_pr_title.yml
@@ -1,6 +1,5 @@
 name: Check PR title
 on:
-  merge_group:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
## Description

As it can't run there, see [here](https://github.com/polyphene/kythera/actions/runs/4355105346) for more info, solution for now is to remove it from required checks
