### PR TITLE
feat(lib): add test MethodType and possible outputs.

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,7 +29,7 @@ fn test(args: TestArgs) -> anyhow::Result<()> {
     for test in tests {
         let mut tester = Tester::new();
         tester.deploy_target_actor(test.actor)?;
-        tester.test(&test.tests)?;
+        tester.test(&test.tests, None)?;
     }
     Ok(())
 }

--- a/common/src/error.rs
+++ b/common/src/error.rs
@@ -4,6 +4,8 @@
 /// Kythera common errors.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Method name `{0}` is invalid")]
+    InvalidMethodName(String),
     #[error("Could not generate method number for `{name}`")]
     MethodNumberGeneration {
         name: String,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -20,6 +20,7 @@ use fvm_shared::{
     version::NetworkVersion,
 };
 
+use crate::error::WrapFVMError;
 use error::Error;
 use state_tree::{BuiltInActors, StateTree};
 
@@ -258,8 +259,6 @@ impl Tester {
                                     Ok(apply_ret) => {
                                         match (method.r#type(), apply_ret.msg_receipt.exit_code) {
                                             (MethodType::Test, ExitCode::OK)
-                                            | (MethodType::Constructor, ExitCode::OK)
-                                            | (MethodType::SetUp, ExitCode::OK)
                                             | (
                                                 MethodType::TestFail,
                                                 ExitCode::USR_ASSERTION_FAILED,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -3,6 +3,7 @@
 use cid::Cid;
 
 pub use kythera_common::abi::{pascal_case_split, Abi};
+use kythera_common::abi::{Method, MethodType};
 use kythera_fvm::{
     engine::EnginePool,
     executor::{ApplyKind, ApplyRet, Executor, KytheraExecutor},
@@ -13,7 +14,8 @@ use kythera_fvm::{
 
 use fvm_ipld_blockstore::Blockstore;
 use fvm_shared::{
-    address::Address, bigint::Zero, econ::TokenAmount, message::Message, version::NetworkVersion,
+    address::Address, bigint::Zero, econ::TokenAmount, error::ExitCode, message::Message,
+    version::NetworkVersion,
 };
 
 use crate::error::WrapFVMError;
@@ -75,11 +77,38 @@ struct DeployedActor {
     address: Address,
 }
 
-/// An Actor that has been deployed into a `BlockStore`.
+/// Outcome of the test.
 #[derive(Debug)]
-pub struct TestResults {
-    pub test_actor: WasmActor,
-    pub results: Result<Vec<Result<ApplyRet, Error>>, Error>,
+pub enum TestResultType {
+    Passed(ApplyRet),
+    Failed(ApplyRet),
+    Erred(Error),
+}
+
+/// Output of running a [`Method`] of an Actor test.
+#[derive(Debug)]
+pub struct TestResult<'a> {
+    method: &'a Method,
+    ret: TestResultType,
+}
+
+impl<'a> TestResult<'a> {
+    /// Get the [`Method`] tested.
+    pub fn method(&self) -> &Method {
+        &self.method
+    }
+
+    /// Get the [`ApplyRet`] of the test.
+    pub fn ret(&self) -> &TestResultType {
+        &self.ret
+    }
+}
+
+/// Output of testing a list of Tests and its [`Method`]s for a target Actor.
+#[derive(Debug)]
+pub struct TestActorResults<'a> {
+    pub test_actor: &'a WasmActor,
+    pub results: Result<Vec<TestResult<'a>>, Error>,
 }
 
 impl Tester {
@@ -141,7 +170,10 @@ impl Tester {
     }
 
     /// Test an Actor on a `MemoryBlockstore`.
-    pub fn test(&mut self, test_actors: &[WasmActor]) -> Result<Vec<TestResults>, Error> {
+    pub fn test<'a>(
+        &mut self,
+        test_actors: &'a [WasmActor],
+    ) -> Result<Vec<TestActorResults<'a>>, Error> {
         // TODO: Should we clone the `StateTree` before each test run,
         // and make our `Tester` stateless?
         let target = self
@@ -168,8 +200,8 @@ impl Tester {
                     Ok(test_address) => test_address,
                     // Error on deployment, return error as part of [`TestResults`]
                     Err(err) => {
-                        return TestResults {
-                            test_actor: test_actor.clone(),
+                        return TestActorResults {
+                            test_actor,
                             results: Err(err),
                         }
                     }
@@ -184,39 +216,56 @@ impl Tester {
                 // one possible concurrent engine.
                 // The following steps will not end up in a result. Either we could finalize message
                 // handling and we return the related ApplyRet or we return nothing.
-                TestResults {
-                    test_actor: test_actor.clone(),
-                    results: Ok(test_actor
-                        .abi
-                        .methods
-                        .iter()
-                        .map(|method| {
-                            let blockstore = self.state_tree.store().clone();
+                TestActorResults {
+                    test_actor,
+                    results: Ok(
+                        test_actor
+                            .abi
+                            .methods
+                            .iter()
+                            .map(|method| {
+                                let blockstore = self.state_tree.store().clone();
 
-                            let mut executor =
-                                Self::new_executor(blockstore, root, self.builtin_actors.root);
+                                let mut executor =
+                                    Self::new_executor(blockstore, root, self.builtin_actors.root);
 
-                            let message = Message {
-                                from: self.account.1,
-                                to: test_address,
-                                gas_limit: 1000000000,
-                                method_num: method.number,
-                                params: target_id.clone().into(),
-                                ..Message::default()
-                            };
+                                let message = Message {
+                                    from: self.account.1,
+                                    to: test_address,
+                                    gas_limit: 1000000000,
+                                    method_num: method.number(),
+                                    params: target_id.clone().into(),
+                                    ..Message::default()
+                                };
 
-                            log::info!(
-                                "Testing test {}.{}() for Actor {}",
-                                test_actor.name,
-                                method.name,
-                                target.name
-                            );
-                            let apply_ret = executor
-                                .execute_message(message, ApplyKind::Explicit, 100)
-                                .tester_err("Couldn't execute message")?;
-                            Ok(apply_ret)
-                        })
-                        .collect()),
+                                log::info!(
+                                    "Testing test {}.{}() for Actor {}",
+                                    test_actor.name,
+                                    method.name(),
+                                    target.name
+                                );
+                                let message = executor
+                                    .execute_message(message, ApplyKind::Explicit, 100)
+                                    .tester_err("Couldn't execute message");
+
+                                let ret = match message {
+                                    Ok(apply_ret) => {
+                                        match (method.r#type(), apply_ret.msg_receipt.exit_code) {
+                                            (MethodType::Test, ExitCode::OK)
+                                            | (
+                                                MethodType::TestFail,
+                                                ExitCode::USR_ASSERTION_FAILED,
+                                            ) => TestResultType::Passed(apply_ret),
+                                            _ => TestResultType::Failed(apply_ret),
+                                        }
+                                    }
+                                    Err(err) => TestResultType::Erred(err),
+                                };
+
+                                TestResult { method, ret }
+                            })
+                            .collect(),
+                    ),
                 }
             })
             .collect())
@@ -333,14 +382,8 @@ mod tests {
         let test_wasm_bin: Vec<u8> = Vec::from(BASIC_TEST_ACTOR_BINARY);
         let test_abi = Abi {
             methods: vec![
-                Method {
-                    number: 3948827889,
-                    name: String::from("TestOne"),
-                },
-                Method {
-                    number: 891686990,
-                    name: String::from("TestTwo"),
-                },
+                Method::new_from_name("TestOne").unwrap(),
+                Method::new_from_name("TestTwo").unwrap(),
             ],
         };
         let test_actor = WasmActor::new(String::from("Basic"), test_wasm_bin, test_abi);
@@ -359,7 +402,7 @@ mod tests {
             Ok(test_res) => {
                 assert_eq!(test_res.len(), 1usize);
                 assert_eq!(test_res[0].results.as_ref().unwrap().len(), 2usize);
-                assert_eq!(test_res[0].test_actor, test_actor);
+                assert_eq!(test_res[0].test_actor, &test_actor);
 
                 test_res[0]
                     .results
@@ -367,19 +410,21 @@ mod tests {
                     .unwrap()
                     .iter()
                     .enumerate()
-                    .for_each(|(i, option_apply_ret)| match option_apply_ret {
-                        Ok(apply_ret) => {
-                            assert_eq!(apply_ret.msg_receipt.exit_code, ExitCode::OK);
-                            let ret_value: String =
-                                apply_ret.msg_receipt.return_data.deserialize().unwrap();
-                            if i == 0usize {
-                                assert_eq!(ret_value, String::from("TestOne"))
-                            } else {
-                                assert_eq!(ret_value, String::from("TestTwo"))
+                    .for_each(
+                        |(i, result)| match (result.method().r#type(), result.ret()) {
+                            (MethodType::Test, TestResultType::Passed(apply_ret)) => {
+                                assert_eq!(apply_ret.msg_receipt.exit_code, ExitCode::OK);
+                                let ret_value: String =
+                                    apply_ret.msg_receipt.return_data.deserialize().unwrap();
+                                if i == 0usize {
+                                    assert_eq!(ret_value, String::from("TestOne"))
+                                } else {
+                                    assert_eq!(ret_value, String::from("TestTwo"))
+                                }
                             }
-                        }
-                        _ => panic!("test against basic test actor should pass"),
-                    })
+                            _ => panic!("test against basic test actor should pass"),
+                        },
+                    )
             }
         }
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -20,7 +20,6 @@ use fvm_shared::{
     version::NetworkVersion,
 };
 
-use crate::error::WrapFVMError;
 use error::Error;
 use state_tree::{BuiltInActors, StateTree};
 
@@ -259,6 +258,8 @@ impl Tester {
                                     Ok(apply_ret) => {
                                         match (method.r#type(), apply_ret.msg_receipt.exit_code) {
                                             (MethodType::Test, ExitCode::OK)
+                                            | (MethodType::Constructor, ExitCode::OK)
+                                            | (MethodType::SetUp, ExitCode::OK)
                                             | (
                                                 MethodType::TestFail,
                                                 ExitCode::USR_ASSERTION_FAILED,


### PR DESCRIPTION
## Description

Starts addressing #24 by Introducing the `MethodType` and reworks `lib::test` to have an output with `TestResultType` which tells us if the combination of the `MethodType` and its `apply_ret` code produces a test pass.