### PR TITLE
feat(lib) run Constructor and SetUp before Test's

### DIFF
--- a/cli/src/search.rs
+++ b/cli/src/search.rs
@@ -51,8 +51,8 @@ fn set_abi_extension<P: AsRef<Path>>(path: P) -> anyhow::Result<String> {
         .map_err(|_| anyhow!("Failed to convert abi path to string"))
 }
 
-/// Create a WebAssembly actor from a binary and an Abi.
-fn create_actor<P: AsRef<Path>>(binary_path: P) -> anyhow::Result<WasmActor> {
+/// Read a WebAssembly actor from a binary and an Abi.
+fn read_actor<P: AsRef<Path>>(binary_path: P) -> anyhow::Result<WasmActor> {
     let abi_path = set_abi_extension(&binary_path)?;
 
     let (file_name, bytecode) = read_file_data(binary_path)?;
@@ -97,9 +97,12 @@ pub fn search_files<P: AsRef<Path>>(path: P) -> anyhow::Result<Vec<Test>> {
     let mut tests = vec![];
     for target_actor_path in target_actor_paths {
         // Get target actor.
-        let Ok(target_actor) = create_actor(&target_actor_path) else {
-            log::error!("Could not get target Actor for binary {target_actor_path}");
-            continue;
+        let target_actor = match read_actor(&target_actor_path) {
+            Ok(target_actor) => target_actor,
+            Err(err) => {
+                log::error!("Could not get target Actor for binary {target_actor_path}: {err}");
+                continue;
+            }
         };
 
         let mut actor_tests = vec![];
@@ -123,7 +126,7 @@ pub fn search_files<P: AsRef<Path>>(path: P) -> anyhow::Result<Vec<Test>> {
             }
 
             if test_path.is_file() {
-                let Ok(test) = create_actor(test_path) else {
+                let Ok(test) = read_actor(test_path) else {
                         log::error!("Could not read test file {}", test_path.display());
                         return false;
                 };
@@ -135,7 +138,7 @@ pub fn search_files<P: AsRef<Path>>(path: P) -> anyhow::Result<Vec<Test>> {
                     .filter_map(Result::ok)
                     .filter_map(|tp| tp.into_path().into_os_string().into_string().ok())
                     .filter(|tp| tp.ends_with(".wasm"))
-                    .filter_map(|tp| match create_actor(&tp) {
+                    .filter_map(|tp| match read_actor(&tp) {
                         Ok(actor_test) => Some(actor_test),
                         Err(err) => {
                             log::error!("Could not read test file {}: {err}", tp);

--- a/cli/src/search.rs
+++ b/cli/src/search.rs
@@ -209,16 +209,14 @@ mod tests {
         let dir = tempdir().unwrap();
         let dir_path = dir.path();
         let target_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("Transfer").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("Transfer").unwrap()],
         };
         let test_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("TestTransfer").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("TestTransfer").unwrap()],
         };
 
         // Create target & test actors files.
@@ -242,22 +240,19 @@ mod tests {
         let dir = tempdir().unwrap();
         let dir_path = dir.path();
         let target_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("Transfer").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("Transfer").unwrap()],
         };
         let test_1_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("TestTransferOne").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("TestTransferOne").unwrap()],
         };
         let test_2_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("TestTransferTwo").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("TestTransferTwo").unwrap()],
         };
 
         // Create target actor files.
@@ -291,28 +286,24 @@ mod tests {
         let dir_path = dir.path();
 
         let target_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("Transfer").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("Transfer").unwrap()],
         };
         let test_1_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("TestTransferOne").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("TestTransferOne").unwrap()],
         };
         let test_2_1_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("TestTransferTwoOne").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("TestTransferTwoOne").unwrap()],
         };
         let test_2_2_actor_abi = Abi {
-            methods: vec![
-                Method::new_from_name("Constructor").unwrap(),
-                Method::new_from_name("TestTransferTwoTwo").unwrap(),
-            ],
+            constructor: Method::new_from_name("Constructor").ok(),
+            set_up: None,
+            methods: vec![Method::new_from_name("TestTransferTwoTwo").unwrap()],
         };
 
         // Create target actor files.

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -395,12 +395,18 @@ mod tests {
 
         // Set target actor
         let target_wasm_bin = wat::parse_str(TARGET_WAT).unwrap();
-        let target_abi = Abi { methods: vec![] };
+        let target_abi = Abi {
+            constructor: None,
+            set_up: None,
+            methods: vec![],
+        };
         let target_actor = WasmActor::new(String::from("Target"), target_wasm_bin, target_abi);
 
         // Set test actor
         let test_wasm_bin: Vec<u8> = Vec::from(BASIC_TEST_ACTOR_BINARY);
         let test_abi = Abi {
+            constructor: None,
+            set_up: None,
             methods: vec![
                 Method::new_from_name("TestOne").unwrap(),
                 Method::new_from_name("TestTwo").unwrap(),


### PR DESCRIPTION
## Description

We validate that an `Abi` is valid when deserializing by checking if it only has one `Constructor` and `Setup`. 

## Open Questions

@tchataigner do you know why the test fails?

<!-- Unresolved questions, if any. -->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
