### PR TITLE
feat(cli): add initial version of gas snapshots.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,6 +1092,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,6 +3126,7 @@ dependencies = [
  "clap 4.2.1",
  "colored",
  "comfy-table",
+ "csv",
  "env_logger",
  "kythera-actors",
  "kythera-lib",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -20,12 +20,13 @@ anyhow = "1.0.70"
 clap = { version = "4.1.11", features = ["derive"] }
 colored = "2.0.0"
 comfy-table = "6.1.4"
+csv = "1.2.1"
 env_logger = "0.10.0"
 kythera-lib = { version = "0.1.0", path = "../lib", features = ["colors"] }
 log = "0.4.17"
 optional_struct = "0.3.1"
 path-clean = "1.0.1"
-serde = "1.0.158"
+serde = { version = "1.0.158", features = ["derive"] }
 serde_yaml = "0.9.19"
 thiserror = "1.0.40"
 walkdir = "2.3.3"

--- a/cli/src/commands/gas_snapshot.rs
+++ b/cli/src/commands/gas_snapshot.rs
@@ -1,0 +1,173 @@
+// Copyright 2023 Polyphene.
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::{
+    collections::HashMap,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use kythera_lib::Tester;
+use serde::{Deserialize, Serialize};
+
+use crate::utils::search::search_files;
+
+/// Kythera gas_snapshot command cli arguments.
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    /// Actor files dir.
+    #[clap(long)]
+    path: PathBuf,
+
+    /// Output a diff against a pre-existing snapshot.
+    ///
+    /// By default, the comparison is done with .gas-snapshot.
+    #[clap(long, conflicts_with = "check")]
+    diff: Option<Option<PathBuf>>,
+
+    /// Compare against a pre-existing snapshot, exiting with code 1 if they do not match.
+    ///
+    /// Outputs a diff if the snapshots do not match.
+    ///
+    /// By default, the comparison is done with .gas-snapshot.
+    #[clap(long, conflicts_with = "diff")]
+    check: Option<Option<PathBuf>>,
+}
+
+/// Method name with its cost.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct MethodCost {
+    name: String,
+    cost: u64,
+    passed: bool,
+}
+
+/// Kythera cli test command.
+pub fn snapshot(args: &Args) -> Result<()> {
+    log::info!("Generating gas snapshot");
+    let methods = generate(&args.path)?;
+
+    if let Some(path) = &args.diff {
+        let path = path
+            .as_deref()
+            .unwrap_or_else(|| Path::new(".gas-snapshot"));
+        return diff(&methods, path);
+    }
+
+    if let Some(path) = &args.check {
+        let path = path
+            .as_deref()
+            .unwrap_or_else(|| Path::new(".gas-snapshot"));
+        if check(&methods, path)? {
+            std::process::exit(0)
+        } else {
+            std::process::exit(1)
+        }
+    }
+
+    let file = File::create(".gas-snapshot")?;
+    let mut wtr = csv::Writer::from_writer(file);
+    // we need to serialze each method instead of a Vec of them for readibility.
+    // see https://github.com/BurntSushi/rust-csv/issues/221#issuecomment-767653324
+    for method in methods {
+        wtr.serialize(method)?;
+    }
+    wtr.flush()?;
+
+    Ok(())
+}
+
+/// Output a diff between the `[MethodCost]`s from the [`TestResult`]s and the gas snapshot
+// provided in the input path.
+fn diff(methods: &[MethodCost], path: &Path) -> Result<()> {
+    let file = File::open(path).context("Could not open diff file")?;
+    let mut rdr = csv::Reader::from_reader(file);
+    let former = rdr
+        .deserialize::<MethodCost>()
+        .into_iter()
+        .filter_map(|r| r.ok())
+        .map(|c| (c.name.clone(), c))
+        .collect::<HashMap<_, _>>();
+    let mut total = 0;
+
+    for method in methods {
+        if let Some(c) = former.get(&method.name) {
+            log::info!(
+                "{} : gas used: {} % ",
+                method.name,
+                method.cost as f64 / c.cost as f64 * 100f64
+            );
+            total += method.cost - c.cost;
+        }
+    }
+    log::info!("Total gas dif: {total}");
+    Ok(())
+}
+
+/// Compare the `[MethodCost]`s from the [`TestResult`]s and the gas snapshot
+/// provided in the input path. Returns true if inputs are the same.
+fn check(methods: &[MethodCost], path: &Path) -> Result<bool> {
+    let mut equal = true;
+    let file = File::open(path).context("Could not open check file")?;
+    let mut rdr = csv::Reader::from_reader(file);
+    let former = rdr
+        .deserialize::<MethodCost>()
+        .into_iter()
+        .filter_map(|r| r.ok())
+        .map(|c| (c.name.clone(), c))
+        .collect::<HashMap<_, _>>();
+
+    for method in methods {
+        match former.get(&method.name) {
+            Some(c) => {
+                log::info!(
+                    "{} : gas used: {} % ",
+                    method.name,
+                    method.cost as f64 / c.cost as f64 * 100f64
+                );
+            }
+            None => {
+                log::error!(
+                    "No matching snapshot entry found for \"{}\" in snapshot file",
+                    method.name
+                );
+                equal = false;
+            }
+        }
+    }
+
+    Ok(equal)
+}
+
+/// Generate on the provided path a csv with the gas cost of the list of [`TestResult`]s.
+fn generate(path: &Path) -> Result<Vec<MethodCost>> {
+    let mut costs = vec![];
+    let test_files = search_files(path)?;
+    for test_file in test_files {
+        let mut tester = Tester::new();
+        let actor_name = test_file.actor.name().to_string();
+        tester.deploy_target_actor(test_file.actor)?;
+        for test in test_file.tests {
+            let test_results = tester.test(&test, None)?;
+            let mut passed;
+            for result in test_results {
+                let ret = match result.ret() {
+                    kythera_lib::TestResultType::Passed(ret) => {
+                        passed = true;
+                        ret
+                    }
+                    kythera_lib::TestResultType::Failed(ret) => {
+                        passed = false;
+                        ret
+                    }
+                    kythera_lib::TestResultType::Erred(_) => continue,
+                };
+                let name = format!("{}::{}", actor_name, result.method().name());
+                let cost = ret.msg_receipt.gas_used;
+                costs.push(MethodCost { name, cost, passed });
+            }
+        }
+    }
+    Ok(costs)
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,1 +1,2 @@
-pub(crate) mod test;
+pub mod gas_snapshot;
+pub mod test;

--- a/cli/src/commands/test/mod.rs
+++ b/cli/src/commands/test/mod.rs
@@ -17,7 +17,7 @@ use self::gas_report::GasReport;
 
 /// Kythera test command cli arguments.
 #[derive(clap::Args, Debug)]
-pub(crate) struct Args {
+pub struct Args {
     /// Actor files dir.
     path: PathBuf,
 
@@ -38,7 +38,7 @@ pub(crate) struct Args {
 }
 
 /// Kythera cli test command.
-pub(crate) fn test(args: &Args) -> anyhow::Result<()> {
+pub fn test(args: &Args) -> anyhow::Result<()> {
     let test_targets = search_files(&args.path)?;
     let mut gas_report = GasReport::default();
     let mut tester = Tester::new();

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod commands;
+pub mod utils;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@
 mod commands;
 mod utils;
 
-use commands::test;
+use commands::{gas_snapshot, test};
 use env_logger::Target;
 use log::LevelFilter;
 
@@ -24,6 +24,7 @@ struct Cli {
 enum Commands {
     #[clap(visible_alias = "t")]
     Test(test::Args),
+    Snapshot(gas_snapshot::Args),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -37,6 +38,8 @@ fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
     match &cli.command {
         Some(Commands::Test(args)) => test::test(args)?,
+        Some(Commands::Snapshot(args)) => gas_snapshot::snapshot(args)?,
+        // Help is printed via `arg_required_else_help` in the `Cli` derive `command`.
         None => {}
     }
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,11 +1,8 @@
 // Copyright 2023 Polyphene.
 // SPDX-License-Identifier: Apache-2.0, MIT
 
-mod commands;
-mod utils;
-
-use commands::{gas_snapshot, test};
 use env_logger::Target;
+use kythera_cli::commands::{gas_snapshot, test};
 use log::LevelFilter;
 
 use std::io::Write;

--- a/cli/tests/commands.rs
+++ b/cli/tests/commands.rs
@@ -601,7 +601,63 @@ fn creates_gas_snapshot() {
 }
 
 #[test]
-fn prints_check_differences() {
+fn snapshot_check_success() {
+    let dir = tempdir().unwrap();
+    create_target_and_test_actors(
+        &dir,
+        &[
+            Vec::from(BASIC_TARGET_ACTOR_BINARY),
+            Vec::from(BASIC_TEST_ACTOR_BINARY),
+        ],
+        &[
+            (
+                "Target",
+                Abi {
+                    constructor: Some(Method::new_from_name("Constructor").unwrap()),
+                    set_up: None,
+                    methods: vec![
+                        Method::new_from_name("HelloWorld").unwrap(),
+                        Method::new_from_name("Caller").unwrap(),
+                        Method::new_from_name("Origin").unwrap(),
+                    ],
+                },
+            ),
+            (
+                "Target.t",
+                Abi {
+                    constructor: Some(Method::new_from_name("Constructor").unwrap()),
+                    set_up: Some(Method::new_from_name("Setup").unwrap()),
+                    methods: vec![Method::new_from_name("TestMethodParameter").unwrap()],
+                },
+            ),
+        ],
+    );
+
+    let mut cmd = Command::cargo_bin("kythera").unwrap();
+    let path = dir.path().join(".gas-snapshot");
+
+    cmd.args([
+        "snapshot",
+        &dir.path().to_str().unwrap(),
+        "--snap",
+        path.to_str().unwrap(),
+    ])
+    .assert()
+    .success();
+
+    cmd = Command::cargo_bin("kythera").unwrap();
+    cmd.args([
+        "snapshot",
+        &dir.path().to_str().unwrap(),
+        "--check",
+        path.to_str().unwrap(),
+    ])
+    .assert()
+    .success();
+}
+
+#[test]
+fn snapshot_check_fails_differences() {
     let dir = tempdir().unwrap();
     create_target_and_test_actors(
         &dir,
@@ -650,7 +706,7 @@ fn prints_check_differences() {
 }
 
 #[test]
-fn prints_diff_same_gas_usage() {
+fn snapshpt_prints_diff_same_gas_usage() {
     let dir = tempdir().unwrap();
     create_target_and_test_actors(
         &dir,
@@ -708,7 +764,7 @@ fn prints_diff_same_gas_usage() {
 }
 
 #[test]
-fn prints_diff_more_gas_usage() {
+fn snapshot_prints_diff_more_gas_usage() {
     let dir = tempdir().unwrap();
     create_target_and_test_actors(
         &dir,
@@ -787,7 +843,7 @@ fn prints_diff_more_gas_usage() {
 }
 
 #[test]
-fn prints_diff_less_gas_usage() {
+fn snapshot_prints_diff_less_gas_usage() {
     let dir = tempdir().unwrap();
     create_target_and_test_actors(
         &dir,

--- a/cli/tests/main.rs
+++ b/cli/tests/main.rs
@@ -1,1 +1,0 @@
-mod commands;


### PR DESCRIPTION
## Description

adds initial version of `snapshot` command with `--diff` and `--check` options

## Notes

current output:
```bash
$ kythera-- snapshot --path test_actors/actors3  
Generating gas snapshot
Actor3.t.wasm: testing 5 tests
Actor4.t.wasm: testing 5 tests
```
```bash
$ kythera-- snapshot --path test_actors/actors3  --diff 
Generating gas snapshot
Actor3.t.wasm: testing 5 tests
Actor4.t.wasm: testing 5 tests
Actor3.wasm::TestConstructorSetup : gas used: 100 % 
Actor3.wasm::TestMethodParameter : gas used: 100 % 
Actor3.wasm::TestFailed : gas used: 100 % 
Actor3.wasm::TestFailFailed : gas used: 100 % 
Actor3.wasm::TestFailSuccess : gas used: 100 % 
Actor4.wasm::TestConstructorSetup : gas used: 100 % 
Actor4.wasm::TestMethodParameter : gas used: 100 % 
Actor4.wasm::TestFailed : gas used: 100 % 
Actor4.wasm::TestFailFailed : gas used: 100 % 
Actor4.wasm::TestFailSuccess : gas used: 100 % 
Total gas dif: 0
```
```bash
$ kythera-- snapshot --path test_actors/actors3  --check 
Generating gas snapshot
Actor3.t.wasm: testing 5 tests
Actor4.t.wasm: testing 5 tests
Actor3.wasm::TestConstructorSetup : gas used: 100 % 
Actor3.wasm::TestMethodParameter : gas used: 100 % 
Actor3.wasm::TestFailed : gas used: 100 % 
No matching snapshot entry found for "Actor3.wasm::TestFailFailed" in snapshot file
No matching snapshot entry found for "Actor3.wasm::TestFailSuccess" in snapshot file
Actor4.wasm::TestConstructorSetup : gas used: 100 % 
Actor4.wasm::TestMethodParameter : gas used: 100 % 
Actor4.wasm::TestFailed : gas used: 100 % 
Actor4.wasm::TestFailFailed : gas used: 100 % 
Actor4.wasm::TestFailSuccess : gas used: 100 % 
```

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
